### PR TITLE
fix: increment prose chart version (serve OPA bundle)

### DIFF
--- a/kubernetes/cluster-1/apps/prose-system/prose/app/helmrelease.yaml
+++ b/kubernetes/cluster-1/apps/prose-system/prose/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prose
-      version: 0.0.4
+      version: 0.0.5
       sourceRef:
         kind: HelmRepository
         name: prose


### PR DESCRIPTION
addresses a task in dettanym/prose#15: Input the OPA (target) policy dynamically rather than hard-coding it as an input.